### PR TITLE
Bump upper bound of blaze-html to <0.10

### DIFF
--- a/snap-blaze.cabal
+++ b/snap-blaze.cabal
@@ -23,7 +23,7 @@ Library
 
   Build-depends:
     base       >= 4   && < 5,
-    blaze-html >= 0.5 && < 0.9,
+    blaze-html >= 0.5 && < 0.10,
     snap-core  >= 0.6 && < 1.1
 
 Source-repository head


### PR DESCRIPTION
Please also release a new version or change the cabal file directly on Hackage. Thanks.